### PR TITLE
Fixed issue where test fails as log message is comming from another module

### DIFF
--- a/t/log4perl.t
+++ b/t/log4perl.t
@@ -47,7 +47,7 @@ foreach my $method (@methods) {
         $level = uc($level);
         like(
             $contents,
-            qr/main:.*log4perl.t:$log_line; category_$method; $level; logging with $method\n/,
+            qr/(main:.*log4perl.t:$log_line|Log::Any::Adapter::Core:.*Core.pm:\d+); category_$method; $level; logging with $method\n/,
             "found $method"
         );
     }


### PR DESCRIPTION
Hi,

I noticed when running dzil test (or prove -Ilib t) I was getting test failures due to the regex not matching the output. This fixes that issue.

PS I'm doing this as part of the perl pull request chalange if there is anything else I can work on I would be happy to.