### PR TITLE
add structured logging

### DIFF
--- a/lib/Log/Any/Adapter/Log4perl.pm
+++ b/lib/Log/Any/Adapter/Log4perl.pm
@@ -40,6 +40,16 @@ foreach my $method ( Log::Any->logging_and_detection_methods() ) {
     );
 }
 
+sub structured {
+    my ($adapter, $level, $category, @parts) = @_;
+    my $context = ref($parts[-1]) eq 'HASH'
+        ? pop @parts
+        : {};
+    my $mdc = Log::Log4perl::MDC->get_context;
+    local @{$mdc}{keys %{$context}} = values %{$context};
+    $adapter->$level(@parts);
+}
+
 1;
 
 __END__

--- a/t/log4perl.t
+++ b/t/log4perl.t
@@ -7,13 +7,15 @@ use Test::More;
 use strict;
 use warnings;
 
+my $has_structured_logging = Log::Any::Adapter->VERSION ge '1.5';
+
 my $dir = tempdir( 'log-any-log4perl-XXXX', TMPDIR => 1, CLEANUP => 1 );
 my $conf = "
 log4perl.rootLogger                = WARN, Logfile
 log4perl.appender.Logfile          = Log::Log4perl::Appender::File
 log4perl.appender.Logfile.filename = $dir/test.log
 log4perl.appender.Logfile.layout   = Log::Log4perl::Layout::PatternLayout
-log4perl.appender.Logfile.layout.ConversionPattern = %C:%F:%L; %c; %p; %m%n
+log4perl.appender.Logfile.layout.ConversionPattern = %C:%F:%L; %c; %p; %m %X{mdc_key}%n
 ";
 Log::Log4perl::init( \$conf );
 Log::Any::Adapter->set('Log::Log4perl');
@@ -23,6 +25,7 @@ push( @methods, ( map { $_ . "f" } @methods ) );
 
 my $test_count =
   scalar(@methods) +
+  ($has_structured_logging ? scalar(@methods) : 0) +
   scalar( Log::Any->detection_methods ) +
   scalar( Log::Any->detection_aliases );
 plan tests => $test_count;
@@ -31,9 +34,12 @@ my $next_line;
 foreach my $method (@methods) {
     my $log = Log::Any->get_logger( category => "category_$method" );
     $log->$method("logging with $method");
+    $log->$method("structured with $method",{mdc_key=>"mdc $method"})
+        if $has_structured_logging;
     $next_line = __LINE__;
 }
-my $log_line = $next_line - 1;
+my $log_line = $next_line - 3;
+my $structured_log_line = $next_line - 2;
 my $contents = read_file("$dir/test.log");
 foreach my $method (@methods) {
     ( my $level = $method ) =~ s/f$//;
@@ -47,12 +53,31 @@ foreach my $method (@methods) {
         $level = uc($level);
         like(
             $contents,
-            qr/main:.*log4perl.t:$log_line; category_$method; $level; logging with $method\n/,
+            qr/main:.*log4perl.t:$log_line; category_$method; $level; logging with $method \[undef\]\n/,
             "found $method"
         );
+
+        if ($has_structured_logging) {
+            if ($method =~ /f$/) {
+                like(
+                    $contents,
+                    qr/main:.*log4perl.t:$structured_log_line; category_$method; $level; structured with $method \[undef\]\n/,
+                    "found $method structured"
+                );
+            }
+            else {
+                like(
+                    $contents,
+                    qr/main:.*log4perl.t:$structured_log_line; category_$method; $level; structured with $method mdc $method\n/,
+                    "found $method structured"
+                );
+            }
+        }
     }
     else {
         unlike( $contents, qr/logging with $method/, "did not find $method" );
+        unlike( $contents, qr/structured with $method/, "did not find $method structured" )
+            if $has_structured_logging;
     }
 }
 my $log = Log::Any->get_logger();


### PR DESCRIPTION
Log::Any supports passing hashrefs to the adapters since version 1.5, let's map it to MDC

The test should still pass on older versions of Log::Any